### PR TITLE
Hotfix: rankmath.schemas double-serialised by WP maybe_serialize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests>=2.31.0
 PyYAML>=6.0
 mistune>=3.2.0
 pytest>=7.0
-phpserialize>=1.3

--- a/skills/wp-post/references/frontmatter.md
+++ b/skills/wp-post/references/frontmatter.md
@@ -50,10 +50,10 @@ rankmath:                      # Rank Math SEO plugin
 # instead of a stale override. An empty/absent excerpt leaves it untouched.
 #
 # rankmath.schemas: each key becomes a rank_math_schema_<Type> post_meta row
-# holding the PHP-serialised schema body, which Rank Math reads back into the
-# page's JSON-LD @graph on render. Upsert per type - a type not listed in a
-# subsequent publish is NOT removed (there is no delete-orphan pass). Empty
-# {} is a no-op; the key being absent leaves existing rows untouched.
+# holding the schema body, which Rank Math reads back into the page's JSON-LD
+# @graph on render. Upsert per type - a type not listed in a subsequent publish
+# is NOT removed (there is no delete-orphan pass). Empty {} is a no-op; the key
+# being absent leaves existing rows untouched.
 
 translation_set: about-us       # MSLS translation group key (multisite only)
 ---

--- a/tests/test_wp_post.py
+++ b/tests/test_wp_post.py
@@ -798,7 +798,6 @@ class TestRankmathSchemasFrontmatter:
     @patch("wp_post.requests.post")
     @patch("wp_post.requests.get")
     def test_populated_schemas_written_after_scalar_meta(self, mock_get, mock_post, wp, md_file, mock_response):
-        import phpserialize
         howto = {"@type": "HowTo", "name": "How"}
         path = md_file(
             {"title": "T", "rankmath": {"title": "SEO", "schemas": {"HowTo": howto}}},
@@ -817,9 +816,12 @@ class TestRankmathSchemasFrontmatter:
         assert len(rm_calls) == 2
         scalar_meta = rm_calls[0][1]["json"]["meta"]
         assert "rank_math_schemas" not in scalar_meta  # .pop worked
+        # Schema body goes over the wire as a nested dict; the WP REST layer
+        # decodes it and update_post_meta single-serialises via maybe_serialize.
+        # Pre-PHP-serialising in Python would trigger maybe_serialize's
+        # double-wrap safety and store corrupted data (see issue #24 hotfix).
         schema_meta = rm_calls[1][1]["json"]["meta"]
-        assert schema_meta["rank_math_schema_HowTo"] == \
-               phpserialize.dumps(howto).decode("utf-8")
+        assert schema_meta["rank_math_schema_HowTo"] == howto
 
     @patch("wp_post.requests.post")
     @patch("wp_post.requests.get")
@@ -3359,55 +3361,6 @@ class TestTestModeLocale:
         assert "Warning</strong>" in capsys.readouterr().out
 
 
-class TestPhpSerialize:
-    """Pins the phpserialize contract wp-post relies on for schema meta."""
-
-    def test_dict_round_trip(self):
-        import phpserialize
-        data = {"@type": "HowTo", "name": "Test"}
-        serialised = phpserialize.dumps(data).decode("utf-8")
-        assert serialised.startswith("a:2:")
-        loaded = phpserialize.loads(serialised.encode("utf-8"), decode_strings=True)
-        assert loaded == data
-
-    def test_nested_list_serialises_as_php_indexed_array(self):
-        # PHP has no distinct list type; Python lists serialise as PHP arrays
-        # with integer keys 0..N-1. This is what Rank Math's unserialize() will
-        # decode back into an indexed PHP array on the server side - exactly
-        # what HowTo's `step` field expects. The Python round-trip via
-        # phpserialize.loads returns those as numeric-keyed dicts (there is no
-        # ambiguity in the serialised form to distinguish list from dict), so
-        # we pin on the serialised string plus the round-tripped dict shape.
-        import phpserialize
-        data = {
-            "@type": "HowTo",
-            "step": [
-                {"@type": "HowToStep", "text": "First"},
-                {"@type": "HowToStep", "text": "Second"},
-            ],
-        }
-        serialised = phpserialize.dumps(data).decode("utf-8")
-        # step is an a:2 array with i:0 / i:1 numeric keys - indexed, not hash.
-        assert 'a:2:{s:5:"@type";s:5:"HowTo";s:4:"step";a:2:{i:0;' in serialised
-        assert '"First"' in serialised
-        assert '"Second"' in serialised
-        loaded = phpserialize.loads(serialised.encode("utf-8"), decode_strings=True)
-        assert loaded == {
-            "@type": "HowTo",
-            "step": {
-                0: {"@type": "HowToStep", "text": "First"},
-                1: {"@type": "HowToStep", "text": "Second"},
-            },
-        }
-
-    def test_unicode_survives(self):
-        import phpserialize
-        data = {"description": "So senden Sie ein PDF per Fax."}
-        serialised = phpserialize.dumps(data).decode("utf-8")
-        loaded = phpserialize.loads(serialised.encode("utf-8"), decode_strings=True)
-        assert loaded == data
-
-
 class TestUpdateRankmathSchemas:
     """Direct tests for the update_rankmath_schemas method (issue #24)."""
 
@@ -3419,7 +3372,6 @@ class TestUpdateRankmathSchemas:
 
     @patch("wp_post.requests.post")
     def test_single_schema_written(self, mock_post, wp, mock_response):
-        import phpserialize
         mock_post.return_value = mock_response(200)
         schema = {"@type": "HowTo", "name": "Test"}
         result = wp.update_rankmath_schemas(1, {"HowTo": schema})
@@ -3430,8 +3382,12 @@ class TestUpdateRankmathSchemas:
         payload = mock_post.call_args[1]["json"]
         assert payload["objectType"] == "post"
         assert payload["objectID"] == 1
-        expected = phpserialize.dumps(schema).decode("utf-8")
-        assert payload["meta"]["rank_math_schema_HowTo"] == expected
+        # Sent as a nested dict, not a PHP-serialised string. WP's
+        # update_post_meta calls maybe_serialize which single-serialises the
+        # array once. Pre-serialising in Python would trip maybe_serialize's
+        # is_serialized() safety wrap (core.trac 12930) and store corrupted
+        # double-wrapped data that fatals Rank Math on render.
+        assert payload["meta"]["rank_math_schema_HowTo"] == schema
 
     @patch("wp_post.requests.post")
     def test_multiple_schemas_one_post(self, mock_post, wp, mock_response):
@@ -3474,15 +3430,20 @@ class TestUpdateRankmathSchemas:
         assert "status_code" not in result
 
     @patch("wp_post.requests.post")
-    def test_serialisation_failure_returns_failure_dict(self, mock_post, wp):
-        # Sets aren't PHP-serialisable; this must surface as schema_failure,
-        # not raise a traceback.
+    def test_json_encoding_failure_returns_failure_dict(self, mock_post, wp):
+        # requests.post(json=payload) internally calls json.dumps; an
+        # unencodable schema value (a set, a datetime YAML autoparsed from a
+        # date-like string) raises TypeError there. It's not a
+        # RequestException, so we catch it explicitly and surface it as
+        # schema_failure instead of a traceback.
+        mock_post.side_effect = TypeError(
+            "Object of type set is not JSON serializable"
+        )
         result = wp.update_rankmath_schemas(1, {"BadType": {"members": {1, 2, 3}}})
         assert result is not None
-        assert "serialisation" in result["error"].lower()
+        assert "JSON serializable" in result["error"]
         assert result["types"] == ["BadType"]
         assert "status_code" not in result
-        mock_post.assert_not_called()
 
 
 class TestRankmathLegacyKeys:

--- a/wp-post.py
+++ b/wp-post.py
@@ -20,7 +20,6 @@ import sys
 import time
 from pathlib import Path
 from urllib.parse import urlparse
-import phpserialize
 import requests
 import yaml
 
@@ -813,8 +812,8 @@ class WordPressPost:
 
             # Handle Rank Math SEO meta via dedicated API.
             rankmath_meta = dict(frontmatter.get('rankmath', {}))
-            # rankmath.schemas is a nested dict of PHP-serialised schema bodies
-            # handled by update_rankmath_schemas below, not by update_rankmath_meta.
+            # rankmath.schemas is a nested dict of schema bodies handled by
+            # update_rankmath_schemas below, not by update_rankmath_meta.
             # Pop it out so (a) the schema value routes to the correct writer and
             # (b) an otherwise-empty rankmath block doesn't trigger a scalar-meta
             # update just because 'schemas' was present. See issue #24.
@@ -945,14 +944,23 @@ class WordPressPost:
             print(f"⚠ Rank Math meta update error: {e}")
 
     def update_rankmath_schemas(self, post_id, schemas, verbose=False):
-        """Write PHP-serialised rank_math_schema_<Type> meta via Rank Math updateMeta.
+        """Write rank_math_schema_<Type> meta via Rank Math updateMeta.
 
-        Each key in `schemas` becomes a `rank_math_schema_<key>` post_meta row,
-        with the value PHP-serialised so Rank Math's schema module reads it back
+        Each key in `schemas` becomes a `rank_math_schema_<key>` post_meta row
+        holding the schema body, which Rank Math's schema module reads back
         into JSON-LD on render. Uses update_post_meta upsert semantics: an
         existing row for the same type is replaced. Types not listed in `schemas`
         are left alone; there is no delete-orphan pass (no REST route enumerates
         existing schema meta_ids). See issue #24.
+
+        The schema body is sent as a native JSON object (nested dict). The WP
+        REST layer decodes it into a PHP associative array, Rank Math calls
+        update_post_meta with the array, and WP's maybe_serialize single-
+        serialises it into wp_postmeta. Pre-PHP-serialising it in Python
+        instead would trigger maybe_serialize's is_serialized() safety wrap
+        (WP core intentionally double-serialises pre-serialised strings, see
+        core.trac 12930), storing corrupted data that fatals Rank Math on
+        render.
 
         Args:
             post_id: WordPress post ID.
@@ -961,25 +969,15 @@ class WordPressPost:
         Returns:
             None on success or when schemas is empty.
             On HTTP failure: {"status_code": int, "error": str, "types": [str]}.
-            On request exception: {"error": str, "types": [str]}.
-            On serialisation failure: {"error": str, "types": [str]}.
+            On request exception or JSON-encoding failure of the payload:
+                {"error": str, "types": [str]}.
         """
         if not schemas:
             return None
 
         types = sorted(schemas.keys())
-        try:
-            meta = {
-                f"rank_math_schema_{type_name}": phpserialize.dumps(schema_body).decode("utf-8")
-                for type_name, schema_body in schemas.items()
-            }
-        except Exception as e:
-            # Most likely a value phpserialize can't handle (datetime autoparsed
-            # by YAML, nested tuple, etc.). Surface as schema_failure so the
-            # publish still succeeds cleanly instead of raising a traceback.
-            print(f"⚠ Rank Math schema serialisation error: {e}", file=sys.stderr)
-            return {"error": f"serialisation: {e}", "types": types}
-
+        meta = {f"rank_math_schema_{type_name}": schema_body
+                for type_name, schema_body in schemas.items()}
         payload = {
             "objectType": "post",
             "objectID": post_id,
@@ -992,6 +990,11 @@ class WordPressPost:
             print(f"[verbose] Types: {types}")
 
         try:
+            # requests JSON-encodes `payload` before the network call. An
+            # unencodable schema value (a set, a datetime that YAML autoparsed
+            # from a date-like string) raises TypeError from json.dumps inside
+            # requests, which is not a RequestException; catch both so a bad
+            # value surfaces as schema_failure rather than a traceback.
             resp = requests.post(url, auth=self.auth, json=payload, timeout=15)
             if resp.status_code == 200:
                 print(f"✓ Rank Math schemas written: {', '.join(types)}")
@@ -1005,7 +1008,7 @@ class WordPressPost:
                 "error": resp.text,
                 "types": types,
             }
-        except requests.RequestException as e:
+        except (requests.RequestException, TypeError, ValueError) as e:
             print(f"⚠ Rank Math schema write error: {e}", file=sys.stderr)
             return {"error": str(e), "types": types}
 
@@ -2245,7 +2248,7 @@ frontmatter fields:
                     title, description, focus_keyword
                   Full rank_math_* keys also accepted.
                   rankmath.schemas: {Type: {...}} writes each schema body
-                  as rank_math_schema_<Type> (PHP-serialised) for JSON-LD
+                  as a rank_math_schema_<Type> post_meta row for JSON-LD
                   rich snippets (HowTo, Recipe, Product, etc.). Upsert per
                   type; types not listed are left alone. Legacy
                   rich_snippet / snippet_howto_* keys are warned and dropped.


### PR DESCRIPTION
Follow-up to #25 (issue #24). Reported live from a peer session on \`payperfax-content\` after republishing an article via the shipped wp-post fataled the live page.

## The bug

\`update_rankmath_schemas\` PHP-serialised the schema body in Python before POSTing it as a string meta value to Rank Math's \`updateMeta\` route. That route calls \`update_post_meta\`, which passes the value through WP core's \`maybe_serialize\`:

\`\`\`php
function maybe_serialize( \$data ) {
    if ( is_array( \$data ) || is_object( \$data ) ) {
        return serialize( \$data );
    }
    /*
     * Double serialization is required for backward compatibility.
     * See https://core.trac.wordpress.org/ticket/12930
     */
    if ( is_serialized( \$data, false ) ) {
        return serialize( \$data );
    }
    return \$data;
}
\`\`\`

WP intentionally **double-wraps** pre-serialised strings for backward-compat. Our row landed as \`s:1699:\"a:4:{...}\"\` in \`wp_postmeta\`. On render, \`maybe_unserialize\` unwraps once, hands Rank Math a string where it expects an array, and the JSON-LD renderer fatals mid-page.

## Repro

Peer republished \`content/de/faxfaq/fax-pdf/index.md\` (post 165, DE subsite) via wp-post from \`master@56a1e18\`. CLI reported success. Live page \`https://payperfax.com/de/how-to/pdf-faxen/\` dropped to 1497 bytes of truncated HTML (head-only, no \`</head>\`). Recovery required \`wp post meta delete 165 rank_math_schema_HowTo\` + the shortcut row.

I'd also seen the smoking gun in my own PR #25 smoke test but misread it: Rank Math's response body echoed the schema back as a **string** value (\`\"schema-26655\":\"a:4:{...}\"\`). \`DB::get_schemas\` calls \`maybe_unserialize\` on the stored value; a string return means the stored value was double-wrapped. I attributed the missing draft-preview HowTo to a "draft rendering quirk" and shipped.

## The fix

One-line change: send the schema body as a native dict. \`requests\` JSON-encodes the payload, WP REST decodes it into a PHP associative array, \`update_post_meta\` takes the \`is_array()\` branch of \`maybe_serialize\` and single-serialises correctly. Peer verified against prod DE post 165: DB stores \`a:4:{...}\` (1699 bytes, single-serialised), live page renders HowTo + 5 HowToStep entries.

Downstream:
- \`phpserialize\` dropped from \`requirements.txt\` and \`import phpserialize\` removed from \`wp-post.py\`.
- \`TestPhpSerialize\` (3 tests) deleted - it pinned the broken behaviour.
- \`test_single_schema_written\` and \`test_populated_schemas_written_after_scalar_meta\` now assert the nested-dict wire shape, with a comment naming the \`maybe_serialize\` double-wrap this avoids so nobody re-adds \`phpserialize.dumps\` "for correctness."
- Failure-surface test renamed from \`test_serialisation_failure_...\` to \`test_json_encoding_failure_...\`; the \`try/except\` around \`requests.post\` now also catches \`TypeError\`/\`ValueError\` from \`requests\`' internal \`json.dumps\` on unencodable schema values (sets, YAML-autoparsed datetimes). Still surfaces as \`schema_failure\` cleanly.
- Docstring, \`--help\`, and skill frontmatter reference no longer describe PHP-serialisation.

## Test plan
- [x] Unit tests: 436 passing (was 439; -3 for deleted \`TestPhpSerialize\`, 0 net for the rewritten schema tests).
- [x] WP source verified: \`maybe_serialize\`'s \`is_serialized\` double-wrap branch is exactly the behaviour we hit.
- [x] Peer live-verified corrected wire format against prod DE post 165 (\`payperfax.com/de/how-to/pdf-faxen/\` back to 142.5KB with HowTo rendering).
- [ ] Peer to re-publish DE post 165 via the fixed wp-post from master after merge, to confirm end-to-end.

## Follow-ups after merge
- Peer (payperfax-content session) will: pull master on the box, re-publish DE post 165 via the fixed wp-post, remove the \`payperfax-rankmath-schemas.php\` mu-plugin they were using as a workaround, close PAY-964.
- Any articles previously published via the broken code have corrupted double-wrapped rows and will fatal Rank Math on render. Republishing them via the fixed wp-post overwrites the row correctly.